### PR TITLE
fix: 各種ボタンをコンポーネント化、ボタンをコンポーネントを内包する要素のクラス名を修正

### DIFF
--- a/src/components/CancelCreateButton.tsx
+++ b/src/components/CancelCreateButton.tsx
@@ -5,7 +5,7 @@ type Props = {
   setIsCreated: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-function CancelButton({ isCreated, setIsCreated }: Props) {
+function CancelCreateButton({ isCreated, setIsCreated }: Props) {
   function cancelCreating() {
     setIsCreated(!isCreated);
   }
@@ -17,4 +17,4 @@ function CancelButton({ isCreated, setIsCreated }: Props) {
   );
 }
 
-export default React.memo(CancelButton);
+export default React.memo(CancelCreateButton);

--- a/src/components/CancelDeleteButton.tsx
+++ b/src/components/CancelDeleteButton.tsx
@@ -1,0 +1,16 @@
+import { useAppDispatch } from "../redux/hooks";
+import { toggleShowModal } from "../redux/modalSlice";
+
+export function CancelDeleteButton() {
+  const dispatch = useAppDispatch();
+
+  function closeModal() {
+    dispatch(toggleShowModal());
+  }
+  
+  return (
+    <button className="btn btn-cancel" type="reset" onClick={closeModal}>
+      <span>Cancel</span>
+    </button>
+  );
+}

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -1,0 +1,18 @@
+import { deleteItem } from "../redux/taskSlice";
+import { useAppDispatch } from "../redux/hooks";
+import { toggleShowModal } from "../redux/modalSlice";
+
+export function DeleteButton() {
+  const dispatch = useAppDispatch();
+
+  function deleteHandler() {
+    dispatch(deleteItem());
+    dispatch(toggleShowModal());
+  }
+
+  return (
+    <button className="btn btn-delete" type="button" onClick={deleteHandler}>
+      <span>Delete</span>
+    </button>
+  );
+}

--- a/src/components/InputBlock.tsx
+++ b/src/components/InputBlock.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useState } from "react";
 import { AddButton } from "./AddButton";
-import CancelButton from "./CancelButton";
+import CancelCreateButton from "./CancelCreateButton";
 
 type Props = {
   category: string;
@@ -29,9 +29,9 @@ export function InputBlock({ category, isCreated, setIsCreated }: Props) {
         placeholder="Enter note"
         onChange={onChangeHandler}
       />
-      <div className="btnBox">
+      <div className="btnContainer">
         <AddButton text={text} category={category} />
-        <CancelButton isCreated={isCreated} setIsCreated={setIsCreated} />
+        <CancelCreateButton isCreated={isCreated} setIsCreated={setIsCreated} />
       </div>
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,12 +1,11 @@
 import ReactModal from "react-modal";
-import { useAppDispatch, useAppSelector } from "../redux/hooks";
-import { deleteItem } from "../redux/taskSlice";
-import { toggleShowModal } from "../redux/modalSlice";
+import { useAppSelector } from "../redux/hooks";
+import { DeleteButton } from "./DeleteButton";
+import { CancelDeleteButton } from "./CancelDeleteButton";
 import "../css/modal.css";
 
 export function Modal() {
   const modalIsOpen = useAppSelector((state) => state.modal.modalIsOpen);
-  const dispatch = useAppDispatch();
   const customModalStyles = {
     content: {
       inset: "0",
@@ -16,15 +15,6 @@ export function Modal() {
     },
   };
 
-  function deleteHandler() {
-    dispatch(deleteItem());
-    dispatch(toggleShowModal());
-  }
-
-  function closeModal() {
-    dispatch(toggleShowModal());
-  }
-
   return (
     <ReactModal
       isOpen={modalIsOpen}
@@ -32,17 +22,9 @@ export function Modal() {
       ariaHideApp={false}
     >
       <h2>Are you sure delete?</h2>
-      <div className="btnBox">
-        <button
-          className="btn btn-delete"
-          type="button"
-          onClick={deleteHandler}
-        >
-          <span>Delete</span>
-        </button>
-        <button className="btn btn-cancel" type="reset" onClick={closeModal}>
-          <span>Cancel</span>
-        </button>
+      <div className="btnContainer">
+        <DeleteButton />
+        <CancelDeleteButton />
       </div>
     </ReactModal>
   );

--- a/src/css/board.css
+++ b/src/css/board.css
@@ -41,7 +41,7 @@
   padding: 10px;
   border-color: #dcdcdc;
 }
-.btnBox {
+.btnContainer {
   display: flex;
   gap: 6px;
   align-items: center;


### PR DESCRIPTION
## やったこと
* 削除ボタン、削除キャンセルボタン、作成キャンセルボタンをコンポーネント化
* べた書きしていたボタンをボタンコンポーネントとして出力する方法に修正
* ボタンコンポーネントを内包するdiv要素のクラス名を修正